### PR TITLE
fix: episode progress tracking across seasons

### DIFF
--- a/feature/mobile/player/src/main/java/com/flixclusive/feature/mobile/player/controls/episodes/composables/EpisodeCard.kt
+++ b/feature/mobile/player/src/main/java/com/flixclusive/feature/mobile/player/controls/episodes/composables/EpisodeCard.kt
@@ -69,7 +69,9 @@ internal fun EpisodeCard(
         val episodeProgress = watchHistoryItem
             .episodesWatched
             .find {
-                it.episodeId == data.id
+                it.episodeId == data.id &&
+                it.seasonNumber == data.season &&
+                it.episodeNumber == data.number
             }
 
         when {


### PR DESCRIPTION
## Description

Fixed an issue where watching an episode would incorrectly mark all episodes with the same number across different seasons as watched. For example, when a user watched part of an episode (e.g., S22E1), all Episode 1s across different seasons would incorrectly show the same progress.

### Changes Made
Updated the episode matching logic in `EpisodeCard.kt`:
```kotlin
val episodeProgress = watchHistoryItem
    .episodesWatched
    .find {
        it.episodeId == data.id &&
        it.seasonNumber == data.season &&
        it.episodeNumber == data.number
    }
```

Fixes #136

## Checklist:

- [x ] I have followed the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for all my commits.
    - Example of a Conventional Commit message: `feat: add new feature to enhance user experience`
